### PR TITLE
limit smart_open req to only use gcs extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'requests==2.23.0',
         'bigquery-schema-generator==0.5.1',
         'jsonlines==1.2.0',
-        'smart-open[all]==4.0.1',
+        'smart-open[gcs]==4.0.1',
         'google-cloud-bigquery==2.15.0'
     ],
     keywords=['DataOps', 'Pipeline'],


### PR DESCRIPTION
requiring [all] extra was causing a ton of unnecessary boto3 dependencies to be installed